### PR TITLE
Do not error if fusion360 directory already exists

### DIFF
--- a/scripts/fusion360-dxvk-install.sh
+++ b/scripts/fusion360-dxvk-install.sh
@@ -90,7 +90,7 @@ if [[ 1 -ne $# ]]; then
    WINEPREFIX=~/.fusion360 sh winetricks -q corefonts vcrun2017 msxml4 dxvk fontsmooth=rgb win10 &&
 
    echo "Autodesk Fusion 360 will be installed and set up."
-   mkdir fusion360 &&
+   mkdir -p fusion360 &&
    cd fusion360 &&
    wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe &&
 

--- a/scripts/fusion360-flatpak-install.sh
+++ b/scripts/fusion360-flatpak-install.sh
@@ -73,7 +73,7 @@ flatpak run org.winehq.flatpak-proton-68-ge-1 winetricks -q corefonts vcrun2017 
 flatpak run org.winehq.flatpak-proton-68-ge-1 bash &&
 cd $HOME &&
 cd Downloads &&
-mkdir fusion360 &&
+mkdir -p fusion360 &&
 cd fusion360 &&
 wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe &&
 

--- a/scripts/fusion360-install.sh
+++ b/scripts/fusion360-install.sh
@@ -89,7 +89,7 @@ if [[ 1 -ne $# ]]; then
    WINEPREFIX=~/.fusion360 sh winetricks -q corefonts vcrun2017 msxml4 fontsmooth=rgb win10 &&
 
    echo "Autodesk Fusion 360 will be installed and set up."
-   mkdir fusion360 &&
+   mkdir -p fusion360 &&
    cd fusion360 &&
    wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe &&
 


### PR DESCRIPTION
Currently in all installation scripts, the `-p` argument is missing, and if you rerun the scripts they exit complaining that the directory already exists. This will prevent that.