### PR TITLE
Automate multilib detection on arch & bugfix

### DIFF
--- a/scripts/stable-branch/fusion360-install.sh
+++ b/scripts/stable-branch/fusion360-install.sh
@@ -491,42 +491,30 @@ esac
 # For the installation of Autodesk Fusion 360 one of the supported Linux distributions must be selected! - Part 2
 
 function archlinux-1 {
-
-HEIGHT=15
-WIDTH=60
-CHOICE_HEIGHT=2
-BACKTITLE="$text_6"
-TITLE="$text_6_1"
-MENU="$text_6_2"
-
-OPTIONS=(1 "$text_6_3"
-         2 "$text_6_4")
-
-CHOICE=$(dialog --clear \
-                --backtitle "$BACKTITLE" \
-                --title "$TITLE" \
-                --menu "$MENU" \
-                $HEIGHT $WIDTH $CHOICE_HEIGHT \
-                "${OPTIONS[@]}" \
-                2>&1 >/dev/tty)
-
-clear
-case $CHOICE in
-        1)
-            archlinux-2 &&
-            select-your-path
-            ;;
-        2)
-            sudo echo "[multilib]" >> /etc/pacman.conf &&
-            sudo echo "Include = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&
-            archlinux-2 &&
-            select-your-path
-            ;;
-esac
+    echo "Checking for multilib..."
+    if archlinux-verify-multilib ; then
+        echo "multilib found. Continuing..."
+        archlinux-2 &&
+        select-your-path
+    else
+        echo "Enabling multilib..."
+        sudo echo "[multilib]" >> /etc/pacman.conf &&
+        sudo echo "Include = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&
+        archlinux-2 &&
+        select-your-path
+    fi
 }
 
 function archlinux-2 {
    sudo pacman -Sy --needed wine wine-mono wine_gecko winetricks p7zip curl cabextract samba ppp
+}
+
+function archlinux-verify-multilib {
+    if cat /etc/pacman.conf | grep -q '^\[multilib\]$' ; then
+        true
+    else
+        false
+    fi
 }
    
 function debian-based-1 {

--- a/scripts/stable-branch/fusion360-install.sh
+++ b/scripts/stable-branch/fusion360-install.sh
@@ -498,8 +498,8 @@ function archlinux-1 {
         select-your-path
     else
         echo "Enabling multilib..."
-        sudo echo "[multilib]" >> /etc/pacman.conf &&
-        sudo echo "Include = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&
+        echo "[multilib]" | sudo tee -a /etc/pacman.conf &&
+        echo "Include = /etc/pacman.d/mirrorlist" | sudo tee -a /etc/pacman.conf &&
         archlinux-2 &&
         select-your-path
     fi


### PR DESCRIPTION
## 📝 Description
Automates the detection of multilib repo on arch.  
Additionally fixes a bug in the arch multilib enabling code.

## 📑 Context
See #98 

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [ ] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
