### PR TITLE
Correct typo in .desktop launcher

### DIFF
--- a/files/Autodesk Fusion 360.desktop
+++ b/files/Autodesk Fusion 360.desktop
@@ -7,4 +7,4 @@ Categories=Development;Graphics;Science
 StartupNotify=true
 Icon=E414_Fusion360.0
 Terminal=false
-Path=/$HOME/.local/share/fusion360
+Path=$HOME/.local/share/fusion360


### PR DESCRIPTION
Remove leading / from launch path before $HOME, which already fills in the root slash.

## 📝 Description
<!--- Describe your changes in detail -->

## 📑 Context
<!--- Why is this change required? What problem does it solve? -->

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [ ] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
