### PR TITLE
Fix Qt6WebEngineCore.dll Patch Path

### DIFF
--- a/files/setup/autodesk_fusion_installer_x86-64.sh
+++ b/files/setup/autodesk_fusion_installer_x86-64.sh
@@ -1145,7 +1145,7 @@ function autodesk_fusion_patch_qt6webenginecore {
     sleep 2
 
     # Copy the patched Qt6WebEngineCore.dll file to the Autodesk Fusion directory
-    cp -f "$SELECTED_DIRECTORY/downloads/Qt6WebEngineCore.dll" "$QT6_WEBENGINECORE_DIR/Qt6WebEngineCore.dll"
+    cp -f "$SELECTED_DIRECTORY/wineprefixes/default/drive_c/users/$USER/Downloads/Qt6WebEngineCore.dll" "$QT6_WEBENGINECORE_DIR/Qt6WebEngineCore.dll"
     echo -e "${GREEN}The Qt6WebEngineCore.dll file is patched successfully!${NOCOLOR}"
 }  
 
@@ -1206,6 +1206,7 @@ function wine_autodesk_fusion_install() {
     # Install 7-Zip inside the Wine prefix via winetricks.
     # This method does NOT require 7-Zip on the host system and is more stable/reliable than previous approaches.
     WINEPREFIX="$SELECTED_DIRECTORY/wineprefixes/default" sh "$SELECTED_DIRECTORY/bin/winetricks" -q 7zip
+    cp "$SELECTED_DIRECTORY/downloads/Qt6WebEngineCore.dll.7z" "$SELECTED_DIRECTORY/wineprefixes/default/drive_c/users/$USER/Downloads/Qt6WebEngineCore.dll.7z"
     WINEPREFIX="$SELECTED_DIRECTORY/wineprefixes/default" wine "$SELECTED_DIRECTORY/wineprefixes/default/drive_c/Program Files/7-Zip/7z.exe" x "C:\\users\\$USER\\Downloads\\Qt6WebEngineCore.dll.7z" -o"C:\\users\\$USER\\Downloads\\"
     # Disabled by Default - Configure the correct virtual desktop resolution
     # WINEPREFIX="$SELECTED_DIRECTORY/wineprefixes/default" sh "$SELECTED_DIRECTORY/bin/winetricks" -q vd="$MONITOR_RESOLUTION"


### PR DESCRIPTION
Fix Qt6WebEngineCore.dll Patch Path. A previous commit switched to extracting inside wine, but did not move the archive into the location expected. This led to the archive not being found by 7zip, and the dll not being copied into the Fusion install as it was still searching in the old location.

## 📝 Description
Fix the patch path locations by adding in an extra copy before attempting extract (line 1209), and fixing source path in patch copy (line 1148)


Note: Date, time and version haven't been changed.

## 📑 Context
Fixes the QtWebEngineCore.dll patching process

## ✅ Checklist:
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
